### PR TITLE
Give Terminal a custom scrollbar

### DIFF
--- a/src/components/Home/Terminal/index.module.css
+++ b/src/components/Home/Terminal/index.module.css
@@ -45,7 +45,7 @@
     &::-webkit-scrollbar:horizontal {
       height: 11px;
     }
-    /* to be deleted comment */
+
     &::-webkit-scrollbar-thumb {
       border-radius: 8px;
       border: 2px solid white;


### PR DESCRIPTION
* using a custom scrollbar instead of the default one should stop mac from taking off the scrollbar automatically 

Fixes #7 