### PR TITLE
Increase typing speed in Terminal

### DIFF
--- a/src/components/Home/Terminal/index.tsx
+++ b/src/components/Home/Terminal/index.tsx
@@ -49,7 +49,7 @@ const Terminal: React.FC<ITerminalProps> = ({ lines, setTypedRef }) => {
     const options = {
       strings: [getTerminalString(lines)],
       smartBackspace: false,
-      typeSpeed: 30,
+      typeSpeed: 20,
       cursorChar: '_',
       onBegin: () => (hasTypingStarted = true),
       onComplete: () => (hasTypingStarted = false),


### PR DESCRIPTION
> 1. Typing on the CLI screen is slow. It is quite boring to watch until I got the idea.

- @dmpetrov in #19 