### PR TITLE
Fix RightPanel content header margin

### DIFF
--- a/src/@dvcorg/gatsby-theme-iterative/components/Documentation/RightPanel/index.tsx
+++ b/src/@dvcorg/gatsby-theme-iterative/components/Documentation/RightPanel/index.tsx
@@ -13,7 +13,7 @@ import {
 import { allImagesLoadedInContainer } from '@dvcorg/gatsby-theme-iterative/src/utils/front/images'
 
 import * as sharedStyles from '@dvcorg/gatsby-theme-iterative/src/components/Documentation/styles.module.css'
-import * as styles from '@dvcorg/gatsby-theme-iterative/src/components/Documentation/RightPanel/styles.module.css'
+import * as styles from './styles.module.css'
 
 interface IRightPanelProps {
   headings: Array<IHeading>

--- a/src/@dvcorg/gatsby-theme-iterative/components/Documentation/RightPanel/styles.module.css
+++ b/src/@dvcorg/gatsby-theme-iterative/components/Documentation/RightPanel/styles.module.css
@@ -1,0 +1,105 @@
+.container {
+  position: sticky;
+  top: var(--layout-header-height);
+  flex-shrink: 0;
+  box-sizing: border-box;
+  width: 170px;
+  height: calc(100vh - 78px);
+  padding-top: 57px;
+  font-size: 16px;
+  display: flex;
+  flex-direction: column;
+
+  @media only screen and (max-width: 1200px) {
+    display: none;
+  }
+}
+
+.contentBlock {
+  overflow-y: scroll;
+  margin-bottom: 27px;
+
+  &::-webkit-scrollbar {
+    appearance: none;
+    width: 7px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 5px;
+    background-color: #7e7e7e;
+  }
+}
+
+.separator {
+  border: none;
+  border-top: 1px solid var(--color-lighter-blue);
+  margin: 12px 0;
+}
+
+.header {
+  font-size: 14px;
+  text-transform: uppercase;
+  color: var(--color-black);
+}
+
+.headingLink {
+  position: relative;
+  display: block;
+  min-height: 26px;
+  margin-bottom: 3px;
+  color: #a0a8a5;
+  text-decoration: none;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 26px;
+  cursor: pointer;
+
+  &.current {
+    color: #000;
+  }
+
+  &:hover {
+    color: #3c3937;
+  }
+}
+
+.buttonsBlock {
+  margin-bottom: 20px;
+  flex-shrink: 0;
+}
+
+.buttonSection {
+  & + & {
+    margin-top: 15px;
+  }
+}
+
+.buttonSectionIcon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 5px;
+}
+
+.buttonSectionDescription {
+  color: var(--color-black);
+}
+
+.button {
+  width: 100%;
+  margin: 10px 0;
+
+  &.tutorials {
+    white-space: nowrap;
+  }
+}
+
+.githubIcon {
+  background-image: url('@dvcorg/gatsby-theme-iterative/src/images/github_icon.svg');
+}
+
+.discordIcon {
+  width: 1.2em;
+  height: 1.2em;
+  background-image: url('@dvcorg/gatsby-theme-iterative/src/images/discord.svg');
+}


### PR DESCRIPTION
unlike dvc.org, this site has a global override on `hr` which removes its margin. This PR adds a shadow to the `RightPanel` stylesheet to re-add that padding.

This is a bit of a band-aid, but I think that's what we want for a few reasons:

- Faster to implement
- Less likely to break other implementations
- Gives us time to see the full breadth of incompatible styles

Before:
![image](https://user-images.githubusercontent.com/9111807/170102791-878f5397-37db-4879-9578-dc2784dd6528.png)

After:
![image](https://user-images.githubusercontent.com/9111807/170102882-7d5d8b1e-f38f-440e-a2af-76e847bfd623.png)

Relates to #63 