### PR TITLE
Fix docs sidebar background spilling into content

### DIFF
--- a/src/components/Footer/index.module.css
+++ b/src/components/Footer/index.module.css
@@ -1,6 +1,5 @@
 .footer {
   padding: 24px 0;
-  margin-top: 24px;
   background-color: #fff;
   @apply border-gray-200 border-solid border-t-2;
 

--- a/src/components/Home/Header/index.module.css
+++ b/src/components/Home/Header/index.module.css
@@ -2,15 +2,15 @@
   text-align: left;
 
   &__title {
-    margin: 24px 0 0;
+    margin: 0;
     @apply text-gradient bg-teal-purple-gradient text-3xl leading-11 font-bold md:text-6xl md:leading-14 lg:text-9xl lg:leading-14;
 
     @media (--md-scr) {
-      margin: 32px 0 0;
+      margin-top: 8px;
     }
 
     @media (--lg-scr) {
-      margin: 40px 0 0 0;
+      margin-top: 16px;
       max-width: 720px;
     }
 

--- a/src/components/Home/index.module.css
+++ b/src/components/Home/index.module.css
@@ -1,0 +1,3 @@
+.homeMain {
+  padding: 24px 0;
+}

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import Header from './Header'
 import Features from './Features'
+import * as styles from './index.module.css'
 
 const Home: React.FC = () => {
   return (
-    <main>
+    <main className={styles.homeMain}>
       <Header />
       <Features />
     </main>


### PR DESCRIPTION
This PR reworks the margin and padding between the footer and the page body, effectively fixing the issue with the sidebar's background spilling into the content area in the docs.

The changes made are:
- Remove top margin from the footer, so each page is in charge of adding its own bottom margin
- Add 24px of padding at the top and bottom of the homepage, re-creating the footer space that was there before
- Trim off 24px of margin in the Home heading at all breakpoints to compensate for the new padding

Before:
![image](https://user-images.githubusercontent.com/9111807/170102244-c0ef1356-bdb1-4d05-b17c-30dc259998af.png)

After:
![image](https://user-images.githubusercontent.com/9111807/170102166-ce7c3826-313e-4d07-ac35-c4e0e051a40a.png)

Home footer still looking fine:
![image](https://user-images.githubusercontent.com/9111807/170102387-c8fdb583-cb95-41aa-a17f-dfe985c85670.png)

Relates to #63 