### PR TITLE
Fix misaligned anchors for `title` and `options`

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,9 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@layer base {
-  svg {
-    display: unset;
-    vertical-align: unset;
-  }
+.anchor svg {
+  display: inline;
+  vertical-align: unset;
 }


### PR DESCRIPTION
tailwind default CSS reset configures the SVG with some defaults that conflicted with the docs-engine setup. Went ahead and reset those defaults.

