### PR TITLE
Added simple linker file to add cmd alias and terms

### DIFF
--- a/content/linked-terms.js
+++ b/content/linked-terms.js
@@ -1,0 +1,6 @@
+module.exports = [
+  {
+    matches: 'mlem ls',
+    url: '/doc/command-reference/list'
+  }
+]

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,6 +16,7 @@ const plugins = [
   {
     resolve: '@dvcorg/gatsby-theme-iterative',
     options: {
+      simpleLinkerTerms: require('./content/linked-terms'),
       cssBase: path.join(
         'src',
         '@dvcorg',


### PR DESCRIPTION
Only added `mlem ls` cmd alias for now.

Need to add others according to usage. CC: @jorgeorpinel 