### PR TITLE
Add link check

### DIFF
--- a/.github/workflows/link-check-all.yml
+++ b/.github/workflows/link-check-all.yml
@@ -1,0 +1,18 @@
+name: Check all links in the repository
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  run:
+    name: Link Check All
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max-http-header-size=65536'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Link Check
+        uses: 'iterative/link-check.action@v0.11'
+        with:
+          configFile: 'config/link-check/config.yml'
+          output: consoleLog

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -2,47 +2,21 @@ name: Check new links against deployment
 # This workflow "triggers" and skips on deployment because GitHub Actions /
 # Checks refuses to show the check on deployment_status
 on:
-  - deployment
   - deployment_status
 jobs:
   run:
-    name: Initialize
+    name: Link Check
     runs-on: ubuntu-latest
-    if:
-      github.event.deployment.ref != 'main' &&
-      github.event.deployment_status.state == 'success'
+    if: github.event.deployment_status.state == 'success'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - id: build_check
-        uses: LouisBrunner/checks-action@v1.0.0
+      - uses: actions/setup-node@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: Report
-          status: queued
-      - name: Run Link Check
+          node-version: 16
+      - name: Check Links
         id: check
-        uses: iterative/link-check.action@v0.11
-        with:
-          diff: main
-          configFile: config/link-check/config.yml
-          rootURL: '${{ github.event.deployment.payload.web_url }}'
-          output: checksAction
-      - uses: LouisBrunner/checks-action@v1.0.0
-        if: ${{ success() }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          check_id: ${{ steps.build_check.outputs.check_id }}
-          status: completed
-          conclusion: ${{ steps.check.outputs.conclusion }}
-          output: ${{ steps.check.outputs.output }}
-      - uses: LouisBrunner/checks-action@v1.0.0
-        if: ${{ failure() }}
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          check_id: ${{ steps.build_check.outputs.check_id }}
-          status: completed
-          conclusion: failure
-          output: >-
-            {"summary": "The Link Check script had an error!"}
+        run:
+          'npx repo-link-check -c config/link-check/config.yml -d main -f -r
+          "${{ github.event.deployment.payload.web_url }}"'

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -1,0 +1,48 @@
+name: Check new links against deployment
+# This workflow "triggers" and skips on deployment because GitHub Actions /
+# Checks refuses to show the check on deployment_status
+on:
+  - deployment
+  - deployment_status
+jobs:
+  run:
+    name: Initialize
+    runs-on: ubuntu-latest
+    if:
+      github.event.deployment.ref != 'master' &&
+      github.event.deployment_status.state == 'success'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - id: build_check
+        uses: LouisBrunner/checks-action@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: Report
+          status: queued
+      - name: Run Link Check
+        id: check
+        uses: iterative/link-check.action@v0.11
+        with:
+          diff: master
+          configFile: config/link-check/config.yml
+          rootURL: '${{ github.event.deployment.payload.web_url }}'
+          output: checksAction
+      - uses: LouisBrunner/checks-action@v1.0.0
+        if: ${{ success() }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check_id: ${{ steps.build_check.outputs.check_id }}
+          status: completed
+          conclusion: ${{ steps.check.outputs.conclusion }}
+          output: ${{ steps.check.outputs.output }}
+      - uses: LouisBrunner/checks-action@v1.0.0
+        if: ${{ failure() }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check_id: ${{ steps.build_check.outputs.check_id }}
+          status: completed
+          conclusion: failure
+          output: >-
+            {"summary": "The Link Check script had an error!"}

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -9,7 +9,7 @@ jobs:
     name: Initialize
     runs-on: ubuntu-latest
     if:
-      github.event.deployment.ref != 'master' &&
+      github.event.deployment.ref != 'main' &&
       github.event.deployment_status.state == 'success'
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
         id: check
         uses: iterative/link-check.action@v0.11
         with:
-          diff: master
+          diff: main
           configFile: config/link-check/config.yml
           rootURL: '${{ github.event.deployment.payload.web_url }}'
           output: checksAction

--- a/config/link-check/config.yml
+++ b/config/link-check/config.yml
@@ -1,0 +1,12 @@
+rootURL: https://dvc.org
+fileIncludePatterns: '{.github,content,src}/**/*!(.test).{css,js,jsx,md,tsx,ts,json}'
+fileExcludePatternFile: config/link-check/excluded-files.yml
+linkExcludePatternFile: config/link-check/excluded-links.yml
+linkOptions:
+  '*.wikipedia.org':
+    minTime: 2000
+    maxConcurrent: 1
+
+  '(*.)?github.com':
+    minTime: 1000
+    maxConcurrent: 1

--- a/config/link-check/config.yml
+++ b/config/link-check/config.yml
@@ -1,4 +1,4 @@
-rootURL: https://dvc.org
+rootURL: https://iterative.ai
 fileIncludePatterns: '{.github,content,src}/**/*!(.test).{css,js,jsx,md,tsx,ts,json}'
 fileExcludePatternFile: config/link-check/excluded-files.yml
 linkExcludePatternFile: config/link-check/excluded-links.yml

--- a/config/link-check/excluded-files.yml
+++ b/config/link-check/excluded-files.yml
@@ -1,0 +1,2 @@
+- 'src/server/**/*'
+- '.github/workflows/**/*'

--- a/config/link-check/excluded-links.yml
+++ b/config/link-check/excluded-links.yml
@@ -1,0 +1,3 @@
+- 'https://marketplace.visualstudio.com/items?itemName=stkb.rewrap'
+- '**linkedin.com/company/**'
+- '/img/<filename>.gif'

--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -9,10 +9,6 @@ In case of a minor change, you can use the **Edit on GitHub** button to open the
 source code page. Use the Edit button (pencil icon) to edit the file in-place,
 and then **Commit changes** from the bottom of the page.
 
-[good link](https://www.google.com) [bad link](https://www.google.com/asdffff)
-[other bad link](www.google.com/asdffff) [nonsense link](asdffffss)
-[other good link](www.google.com)
-
 > Please see our
 > [Writing a Blog Post guide](https://dvc.org/doc/user-guide/contributing/blog)
 > for more details on how to write and submit a new blog post.

--- a/content/docs/contributing/docs.md
+++ b/content/docs/contributing/docs.md
@@ -9,6 +9,10 @@ In case of a minor change, you can use the **Edit on GitHub** button to open the
 source code page. Use the Edit button (pencil icon) to edit the file in-place,
 and then **Commit changes** from the bottom of the page.
 
+[good link](https://www.google.com) [bad link](https://www.google.com/asdffff)
+[other bad link](www.google.com/asdffff) [nonsense link](asdffffss)
+[other good link](www.google.com)
+
 > Please see our
 > [Writing a Blog Post guide](https://dvc.org/doc/user-guide/contributing/blog)
 > for more details on how to write and submit a new blog post.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
     "format": "prettier --write \"**/*.{js,json,css,md}\"",
     "lint-ts": "tsc && eslint --ext .js,.tsx,.ts,.json",
     "check-format": "prettier -c \"**/*.{js,json,css,md}\"",
-    "check-format-and-lint": "npm-run-all format lint-ts"
+    "check-format-and-lint": "npm-run-all format lint-ts",
+    "link-check": "repo-link-check -c config/link-check/config.yml",
+    "link-check-diff": "repo-link-check -c config/link-check/config.yml -d",
+    "link-check-dev-server": "repo-link-check -c config/link-check/config.yml -r http://localhost:3000",
+    "link-check-exclude": "repo-link-check -c config/link-check/config.yml --unusedPatternsOnly"
   },
   "dependencies": {
     "@dvcorg/gatsby-theme-iterative": "^0.1.5",
@@ -46,6 +50,7 @@
     "react-dom": "^18.0.0",
     "react-helmet": "^6.1.0",
     "serve-handler": "^6.1.3",
+    "repo-link-check": "^0.11.0",
     "tailwindcss": "3.0.23",
     "typed.js": "^2.0.12"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4526,6 +4526,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 boxen@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-4.2.0.tgz#e411b62357d6d6d36587c8ac3d5d974daa070e64"
@@ -5080,6 +5085,11 @@ commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@^7.2.0:
   version "7.2.0"
@@ -6810,7 +6820,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-glob@^3.1.1, fast-glob@^3.2.11, fast-glob@^3.2.9:
+fast-glob@^3.1.1, fast-glob@^3.2.11, fast-glob@^3.2.4, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -9286,7 +9296,7 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
+js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -10434,7 +10444,7 @@ micromark@^3.0.0:
     micromark-util-types "^1.0.1"
     uvu "^0.5.0"
 
-micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -12843,6 +12853,19 @@ repeat-string@^1.0.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
+repo-link-check@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/repo-link-check/-/repo-link-check-0.11.0.tgz#07c62b99df21f83dc5bacca55dfc5677dc920fe1"
+  integrity sha512-CffKg4SKFd53TuxuOBjavjsCoYlX6/E0TuELKgljhZ+8lZs9Lm7Lnv+f9sxte0RuaEvY1WKjLYy6yLL/2pQV+A==
+  dependencies:
+    bottleneck "^2.19.5"
+    commander "^6.1.0"
+    fast-glob "^3.2.4"
+    js-yaml "^3.14.0"
+    lodash "^4.17.20"
+    micromatch "^4.0.2"
+    node-fetch "^2.6.0"
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This PR adds our `repo-link-check` package in both GitHub Actions and local npm scripts, with the same implementation that dvc.org currently has.