### PR TITLE
Fix some commands

### DIFF
--- a/content/docs/use-cases/mlem-mr.md
+++ b/content/docs/use-cases/mlem-mr.md
@@ -29,22 +29,20 @@ Let's build an example using
 That repo already have some models in it:
 
 ```cli
-$ mlem ls https://github.com/iterative/example-mlem-get-started
+$ mlem ls https://github.com/iterative/example-mlem-get-started/tree/simple
 ```
 
 ```yaml
-Datasets:
-  - test_x.csv
-  - test_y.csv
-  - train.csv
-Models:
-  - rf
+Builders:
+ - pip_config
 Deployments:
-  - myservice
-Packagers:
-  - pip_config
+ - myservice
 Envs:
-  - staging
+ - staging
+Models:
+ - rf
+Data:
+ - iris.csv
 ```
 
 Let's create new repo first:
@@ -59,11 +57,11 @@ $ mlem init
 Let's create some links to them:
 
 ```cli
-$ mlem link --sr https://github.com/iterative/example-mlem-get-started --rev main rf first-model
+$ mlem link --sp https://github.com/iterative/example-mlem-get-started --rev simple rf first-model
 ⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/main/.mlem/model/rf.mlem
 💾 Saving link to .mlem/link/first-model.mlem
 
-$ mlem link --sr https://github.com/iterative/example-mlem-get-started --rev 7-deploy-meta rf second-model
+$ mlem link --sp https://github.com/iterative/example-mlem-get-started --rev 7-deploy-meta rf second-model
 ⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/7-deploy-meta/.mlem/model/rf.mlem
 💾 Saving link to .mlem/link/second-model.mlem
 ```

--- a/content/docs/use-cases/mlem-mr.md
+++ b/content/docs/use-cases/mlem-mr.md
@@ -34,15 +34,15 @@ $ mlem ls https://github.com/iterative/example-mlem-get-started --rev simple
 
 ```yaml
 Builders:
- - pip_config
+  - pip_config
 Deployments:
- - myservice
+  - myservice
 Envs:
- - staging
+  - staging
 Models:
- - rf
+  - rf
 Data:
- - iris.csv
+  - iris.csv
 ```
 
 Let's create new repo first:

--- a/content/docs/use-cases/mlem-mr.md
+++ b/content/docs/use-cases/mlem-mr.md
@@ -29,7 +29,7 @@ Let's build an example using
 That repo already have some models in it:
 
 ```cli
-$ mlem ls https://github.com/iterative/example-mlem-get-started/tree/simple
+$ mlem ls https://github.com/iterative/example-mlem-get-started --rev simple
 ```
 
 ```yaml
@@ -58,11 +58,11 @@ Let's create some links to them:
 
 ```cli
 $ mlem link --sp https://github.com/iterative/example-mlem-get-started --rev simple rf first-model
-⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/main/.mlem/model/rf.mlem
+⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/simple/.mlem/model/rf.mlem
 💾 Saving link to .mlem/link/first-model.mlem
 
-$ mlem link --sp https://github.com/iterative/example-mlem-get-started --rev 7-deploy-meta rf second-model
-⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/7-deploy-meta/.mlem/model/rf.mlem
+$ mlem link --sp https://github.com/iterative/example-mlem-get-started --rev 5-deploy-meta rf second-model
+⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/5-deploy-meta/.mlem/model/rf.mlem
 💾 Saving link to .mlem/link/second-model.mlem
 ```
 


### PR DESCRIPTION
This fixes a couple of commands in the documentation:
1. listing models from a repo appears appears to either need an explicit `--rev` specified or it should have the `/tree/simple` appended. Not sure which version is preferred.
2. My best attempt at this was using the `simple` branch from the repository. However, that contains different data.
3. The source project is specified by `--sp` rather than `--sr`.

I wasn't sure about another issue: None of the commands seem to work with tags.