### PR TITLE
Show docs on navbar on mobile view

### DIFF
--- a/src/components/NavBar/index.module.css
+++ b/src/components/NavBar/index.module.css
@@ -36,6 +36,7 @@
   display: flex;
   align-items: center;
   padding: 8px 16px;
+  justify-content: center;
 
   @media (--md-scr) {
     padding: 8px 32px;

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -59,7 +59,13 @@ const NavBar: React.FC = () => {
             by <span>iterative.ai</span>
           </SmartLink>
           <div className={styles.nav__links}>
-            <SmartLink href="/doc" className={styles.nav__link}>
+            <SmartLink
+              href="/doc"
+              className={styles.nav__link}
+              style={{
+                display: 'flex'
+              }}
+            >
               Docs
             </SmartLink>
             <SmartLink


### PR DESCRIPTION
Making docs link on navbar visible on mobile view. This is just a quick solution to at least have mobile users easy access to docs and can easily be replaced later. There are better approaches and can be discussed https://github.com/iterative/mlem.ai/issues/117 further.