### PR TITLE
Use actual rootURL for whole-repo check

### DIFF
--- a/config/link-check/config.yml
+++ b/config/link-check/config.yml
@@ -1,4 +1,4 @@
-rootURL: https://iterative.ai
+rootURL: https://mlem.ai
 fileIncludePatterns: '{.github,content,src}/**/*!(.test).{css,js,jsx,md,tsx,ts,json}'
 fileExcludePatternFile: config/link-check/excluded-files.yml
 linkExcludePatternFile: config/link-check/excluded-links.yml


### PR DESCRIPTION
The whole-repo check had `iterative.ai` as its `rootURL`, when it should be `mlem.ai`, and I never noticed because I hadn't been looking at the whole-site check :facepalm: 