### PR TITLE
`init`: cover remote project cases

### DIFF
--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -17,7 +17,10 @@ This creates a `.mlem/` directory and an empty `config.yaml` file in the desired
 project `path`, which defaults to the current working directory (`.`).
 
 The existence of a valid `.mlem/` directory in any location (including [remote])
-allows MLEM to be fully functional.
+allows MLEM to store a references to MLEM objects stored in the project,
+enabling `$ mlem list` command, and configure MLEM
+[to work with DVC](http://localhost:8000/doc/use-cases/dvc) by setting this in
+`.mlem/config.yaml`.
 
 <admon type="tip">
 

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -23,8 +23,8 @@ to MLEM objects found in the project (required by `mlem list`) as well as to
 
 <admon type="tip">
 
-We recommend initializing MLEM projects inside Git repositories to track changes and
-manage them using standard Git workflows.
+We recommend initializing MLEM projects inside Git repositories to track changes
+and manage them using standard Git workflows.
 
 </admon>
 

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -17,10 +17,9 @@ This creates a `.mlem/` directory and an empty `config.yaml` file in the desired
 project `path`, which defaults to the current working directory (`.`).
 
 The existence of a valid `.mlem/` directory in any location (including [remote])
-allows MLEM to store a references to MLEM objects stored in the project,
-enabling `$ mlem list` command, and configure MLEM
-[to work with DVC](http://localhost:8000/doc/use-cases/dvc) by setting this in
-`.mlem/config.yaml`.
+enables all of MLEM's functions. Specifically, it allows for storing references
+to MLEM objects found in the project (required by `mlem list`) as well as to
+[integrate with DVC](/doc/use-cases/dvc).
 
 <admon type="tip">
 

--- a/content/docs/command-reference/init.md
+++ b/content/docs/command-reference/init.md
@@ -7,19 +7,26 @@ Initialize a MLEM project.
 ```usage
 usage: mlem init [options] [path]
 
-arguments: [PATH] Where to init project
+arguments:
+[path]      Location (file path or URL) to initialize a MLEM project
 ```
 
 ## Description
 
-The `init` command (without given `path`) defaults to the current directory for
-the path argument. This creates a `.mlem/` directory and an empty `config.yaml`
-file inside it.
+This creates a `.mlem/` directory and an empty `config.yaml` file in the desired
+project `path`, which defaults to the current working directory (`.`).
 
-Although we recommend using MLEM within a Git repository to track changes using
-the standard Git workflows, this is not required. The existence of a `.mlem/`
-directory in any path (including remote) constitutes a MLEM project, and MLEM
-will be fully functional even without incorporating Git in one's workflow.
+The existence of a valid `.mlem/` directory in any location (including [remote])
+allows MLEM to be fully functional.
+
+<admon type="tip">
+
+We recommend initializing MLEM projects inside Git repositories to track changes
+using standard Git workflows.
+
+</admon>
+
+[remote]: /doc/user-guide/remote-objects
 
 ## Options
 

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -32,8 +32,10 @@ Envs:
 
 <admon type="note">
 
-A MLEM project is required as target for `mlem list`. The other operations
+A [MLEM project] is required as target for `mlem list`. The other operations
 (below) work with loose MLEM objects (not in a MLEM project) as well.
+
+[mlem project]: /doc/command-reference/init
 
 </admon>
 

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -15,7 +15,7 @@ operations apply to any [object type] and location.
 
 ## Listing objects
 
-You can list MLEM objects inside a remote MLEM projects (Git repo) with
+You can list MLEM objects inside a remote MLEM project in a Git repo with
 `mlem list`. There's no need to clone the repo.
 
 ```cli
@@ -33,7 +33,7 @@ Envs:
 <admon type="note">
 
 A MLEM project is required as target for `mlem list`. The other operations
-(below) work with loose MLEM objects as well.
+(below) work with loose MLEM objects (not in a MLEM project) as well.
 
 </admon>
 
@@ -91,7 +91,6 @@ Loose objects are typically stored this way because they do not require
 </admon>
 
 ```cli
-$ mlem init s3://example-mlem-get-started  # Requires S3 auth.
 $ mlem clone rf s3://example-mlem-get-started/rf
 ⏳️ Loading meta from .mlem/model/rf.mlem
 🐏 Cloning .mlem/model/rf.mlem

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -13,10 +13,21 @@ operations apply to any [object type] and location.
 [mlem objects]: /doc/user-guide/basic-concepts#mlem-objects
 [object type]: /doc/user-guide/basic-concepts#mlem-object-types
 
+## Initializing MLEM Project
+
+Although you can store MLEM objects in a Git repo or in a Cloud bucket without
+creating a MLEM project with `$ mlem init`, doing so enables you to organize and
+access your MLEM objects easier.
+
+This creates a `.mlem/` directory in the desired path. By default MLEM will save
+models to `.mlem/model/` and data to `.mlem/data`. If you save MLEM models
+outside of `.mlem/` folder, MLEM will store the reference to it inside `.mlem/`
+folder. This approach allows MLEM to list your MLEM objects in a project.
+
 ## Listing objects
 
-You can list MLEM objects inside a remote MLEM project (e.g. in a Git
-repo) with `mlem list`. There's no need to download/clone the project.
+You can list MLEM objects inside a remote MLEM project (e.g. in a Git repo) with
+`mlem list`. There's no need to download/clone the project.
 
 ```cli
 $ mlem list \

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -16,13 +16,11 @@ operations apply to any [object type] and location.
 ## Remote MLEM projects
 
 Although you can store MLEM objects in any location such as a Git repo, Cloud
-storage, or external drives, creating a MLEM project lets you
-organize and [discover] MLEM objects consistently.
+storage, or external drives, creating a MLEM project lets you organize and
+[discover](#listing-objects) MLEM objects consistently.
 
 To create a MLEM project in a remote location, you can provide its URL or path
 to `mlem init`.
-
-[discover]: /doc/command-reference/list
 
 ## Listing objects
 

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -13,16 +13,16 @@ operations apply to any [object type] and location.
 [mlem objects]: /doc/user-guide/basic-concepts#mlem-objects
 [object type]: /doc/user-guide/basic-concepts#mlem-object-types
 
-## Initializing MLEM Project
+## Remote MLEM projects
 
-Although you can store MLEM objects in a Git repo or in a Cloud bucket without
-creating a MLEM project with `$ mlem init`, doing so enables you to organize and
-access your MLEM objects easier.
+Although you can store MLEM objects in any location such as a Git repo, Cloud
+storage, or external drives, creating a MLEM project lets you
+organize and [discover] MLEM objects consistently.
 
-This creates a `.mlem/` directory in the desired path. By default MLEM will save
-models to `.mlem/model/` and data to `.mlem/data`. If you save MLEM models
-outside of `.mlem/` folder, MLEM will store the reference to it inside `.mlem/`
-folder. This approach allows MLEM to list your MLEM objects in a project.
+To create a MLEM project in a remote location, you can provide its URL or path
+to `mlem init`.
+
+[discover]: /doc/command-reference/list
 
 ## Listing objects
 

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -50,7 +50,7 @@ A [MLEM project] is required as target for `mlem list`. The other operations
 
 ## Loading objects (Python)
 
-You can load objects from remote locations inside Python code with
+You can load [MLEM objects] from remote locations inside Python code with
 `mlem.api.load()` by using an object name and its URL.
 
 ```py
@@ -71,7 +71,7 @@ This fetches the `rf` model [form branch `simple`] of the
 
 ## Downloading objects
 
-You can download MLEM object files to the local environment in with `mlem clone`
+You can download MLEM objects to the local environment in with `mlem clone`
 (CLI).
 
 ```cli
@@ -90,9 +90,9 @@ This places the `rf` model [form branch `simple`] of the
 
 ## Cloud storage
 
-It's also possible to (down)load loose MLEM objects stored in any cloud platform
-[supported by `fsspec`], e.g. Amazon S3. To do so, provide the file system
-protocol & path as target/URL, e.g. `s3://<bucket>/`
+It's also possible to (down)load loose [MLEM objects] stored in any cloud
+platform [supported by `fsspec`], e.g. Amazon S3. To do so, provide the file
+system protocol & path as target/URL, e.g. `s3://<bucket>/`
 
 <admon type="tip">
 


### PR DESCRIPTION
Closes #126

> There should probably be a separate section (in [Remote Objects](https://mlem.ai/doc/user-guide/remote-projects)) to explain that you can initialize MLEM projects in remote locations and give some motivation (why would I do that). The cmd ref. also should be much more emphatic about this.