### PR TITLE
Replacing links from `simple` to `main` branch

### DIFF
--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -54,6 +54,6 @@ $ mlem import data/model.pkl data/imported_model
 Create a MLEM model from remote `.pkl` (pickle) file
 
 ```cli
-$ mlem import .mlem/model/rf --project https://github.com/iterative/example-mlem-get-started --rev simple data/imported_model --type pickle
+$ mlem import .mlem/model/rf --project https://github.com/iterative/example-mlem-get-started --rev main data/imported_model --type pickle
 💾 Saving model to .mlem/model/data/imported_model.mlem
 ```

--- a/content/docs/use-cases/mlem-mr.md
+++ b/content/docs/use-cases/mlem-mr.md
@@ -29,7 +29,7 @@ Let's build an example using
 That repo already have some models in it:
 
 ```cli
-$ mlem ls https://github.com/iterative/example-mlem-get-started --rev simple
+$ mlem ls https://github.com/iterative/example-mlem-get-started
 ```
 
 ```yaml
@@ -57,8 +57,8 @@ $ mlem init
 Let's create some links to them:
 
 ```cli
-$ mlem link --sp https://github.com/iterative/example-mlem-get-started --rev simple rf first-model
-⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/simple/.mlem/model/rf.mlem
+$ mlem link --sp https://github.com/iterative/example-mlem-get-started rf first-model
+⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/main/.mlem/model/rf.mlem
 💾 Saving link to .mlem/link/first-model.mlem
 
 $ mlem link --sp https://github.com/iterative/example-mlem-get-started --rev 5-deploy-meta rf second-model

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -105,7 +105,7 @@ $ mlem clone rf s3://example-mlem-get-started/rf
 💾 Saving model to s3://example-mlem-get-started/.mlem/model/rf.mlem
 ```
 
-The `rf` model from S3 bucket `example-mlem-get-started` can now be
+The `rf` model from S3 bucket `example-mlem-get-started` can also be
 [loaded via API](#loading-objects-api) or used in the CLI as though it existed
 locally:
 

--- a/content/docs/user-guide/remote-objects.md
+++ b/content/docs/user-guide/remote-objects.md
@@ -28,9 +28,7 @@ You can list MLEM objects inside a remote MLEM project (e.g. in a Git repo) with
 `mlem list`. There's no need to download/clone the project.
 
 ```cli
-$ mlem list \
-       https://github.com/iterative/example-mlem-get-started \
-       --rev simple
+$ mlem list https://github.com/iterative/example-mlem-get-started
 Deployments:
  - myservice
 Models:
@@ -59,15 +57,15 @@ from mlem.api import load
 model = load(
     "rf",
     project="https://github.com/iterative/example-mlem-get-started",
-    rev="simple"
+    rev="main"
 )
 ```
 
-This fetches the `rf` model [form branch `simple`] of the
+This fetches the `rf` model [from branch `main`] of the
 `example-mlem-get-started` repo and loads it to memory.
 
-[form branch `simple`]:
-  https://github.com/iterative/example-mlem-get-started/tree/simple/.mlem/model
+[from branch `main`]:
+  https://github.com/iterative/example-mlem-get-started/tree/main/.mlem/model
 
 ## Downloading objects
 
@@ -77,14 +75,13 @@ You can download MLEM objects to the local environment in with `mlem clone`
 ```cli
 $ mlem clone rf \
   --project https://github.com/iterative/example-mlem-get-started \
-  --rev simple \
   ml_model
-⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/simple/.mlem/model/rf.mlem
-🐏 Cloning https://github.com/iterative/example-mlem-get-started/tree/simple/.mlem/model/rf.mlem
+⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/main/.mlem/model/rf.mlem
+🐏 Cloning https://github.com/iterative/example-mlem-get-started/tree/main/.mlem/model/rf.mlem
 💾 Saving model to .mlem/model/ml_model.mlem
 ```
 
-This places the `rf` model [form branch `simple`] of the
+This places the `rf` model [from branch `main`] of the
 `example-mlem-get-started` repo, renames it to `ml_model`, and places it in the
 `.mlem/model` directory.
 


### PR DESCRIPTION
When we updated `example-mlem-get-started` and removed `simple` branch, we forgot to update it in Docs. Fixing that.