### PR TITLE
Improve spelling and grammar

### DIFF
--- a/content/docs/api-reference/apply_remote.md
+++ b/content/docs/api-reference/apply_remote.md
@@ -36,7 +36,7 @@ knows how to make requests to the deployed model.
 - **`data`** (required) - Input to the model.
 - `method` (optional) - Which model method to use. If None, use the only method
   model has. If more than one is available, will fail.
-- `output` (optional) - If value is provided, assume it's path and save output
+- `output` (optional) - If value is provided, assume its path and save output
   there.
 - `target_project` (optional) - The path to project to save the results to.
 - `index` (optional) - Whether to index saved output in MLEM root folder.

--- a/content/docs/api-reference/build.md
+++ b/content/docs/api-reference/build.md
@@ -25,7 +25,7 @@ build("pip", "rf", target="build", package_name="example_mlem_get_started")
 This API is the underlying mechanism for the
 [mlem build](/doc/command-reference/build) command and allows us to
 programmatically create ship-able assets from MlemModels such as pip-ready
-packages, docker images, etc.
+packages, Docker images, etc.
 
 <admon type="tip">
 

--- a/content/docs/api-reference/clone.md
+++ b/content/docs/api-reference/clone.md
@@ -46,7 +46,7 @@ target.
 - `target_fs` (optional) - target filesystem
 - `follow_links` (optional) - If object we read is a MLEM link, whether to load
   the actual object link points to. Defaults to True.
-- `load_value` (optional) - Load actual python object incorporated in MlemMeta
+- `load_value` (optional) - Load actual Python object incorporated in MlemMeta
   object. Defaults to False.
 - `index` (optional) - Whether to index output in .mlem directory
 - `external` (optional) - whether to put object inside mlem dir in target

--- a/content/docs/api-reference/index.md
+++ b/content/docs/api-reference/index.md
@@ -1,6 +1,6 @@
 # Python API
 
-MLEM can be used as a python library, simply [install](/doc/install) with `pip`
+MLEM can be used as a Python library, simply [install](/doc/install) with `pip`
 or `conda`. This reference provides the details about the functions in the API
 module `mlem.api`, which can be imported in any regular way, for example:
 

--- a/content/docs/api-reference/load.md
+++ b/content/docs/api-reference/load.md
@@ -1,6 +1,6 @@
 # mlem.api.load()
 
-Load python object saved by MLEM
+Load Python object saved by MLEM
 
 ```py
 def load(
@@ -24,8 +24,8 @@ loaded = load(out_path)
 
 ## Description
 
-Loads a python object from a given path. The path can belong to different file
-systems (eg: `S3`). The function returns the underlying python object saved by
+Loads a Python object from a given path. The path can belong to different file
+systems (eg: `S3`). The function returns the underlying Python object saved by
 MLEM.
 
 ## Parameters

--- a/content/docs/api-reference/load_meta.md
+++ b/content/docs/api-reference/load_meta.md
@@ -29,9 +29,9 @@ loaded = load_meta(out_path)
 
 Loads a [MlemObject](/doc/user-guide/basic-concepts#mlem-objects) from a given
 path. This differs from [load](/doc/api-reference/load) since the latter loads
-the actual python object incorporated within MlemObject. In fact, `load` uses
+the actual Python object incorporated within MlemObject. In fact, `load` uses
 `load_meta` beneath and uses its `get_value()` method to get the underlying
-python object.
+Python object.
 
 ## Parameters
 
@@ -41,7 +41,7 @@ python object.
 - `rev` (optional) - revision, could be Git commit SHA, branch name or tag.
 - `follow_links` (optional) - If object we read is a MLEM link, whether to load
   the actual object link points to. Defaults to True.
-- `load_value` (optional) - Load actual python object incorporated in
+- `load_value` (optional) - Load actual Python object incorporated in
   MlemObject. Defaults to False.
 - `fs` (optional) - filesystem to load from. If not provided, will be inferred
   from path

--- a/content/docs/api-reference/save.md
+++ b/content/docs/api-reference/save.md
@@ -36,7 +36,7 @@ systems (eg: `S3`). The function returns and saves the object as a
   or `fs` argument should be provided
 - `project` (optional) - path to mlem project
 - `sample_data` (optional) - If the object is a model or function, you can
-  provide input data sample, so MLEM will include it's schema in the model's
+  provide input data sample, so MLEM will include its schema in the model's
   metafile
 - `fs` (optional) - FileSystem for the `path` argument
 - `index` (optional) - Whether to add object to mlem project index

--- a/content/docs/command-reference/apply.md
+++ b/content/docs/command-reference/apply.md
@@ -19,7 +19,7 @@ Applying a model to data means calling a model's method (e.g. `predict`) with
 all the data points in the dataset, and returning the output as a MLEM Object.
 
 This command addresses a very common workflow, replacing the need to write a
-python script to load models & datasets, apply the datasets on the models, and
+Python script to load models & datasets, apply the datasets on the models, and
 saving the results.
 
 Models and Data, which represent

--- a/content/docs/command-reference/build.md
+++ b/content/docs/command-reference/build.md
@@ -31,7 +31,7 @@ images.
 
 ## Examples
 
-Build a docker image from a model
+Build a Docker image from a model
 
 ```cli
 $ mlem build mymodel docker --conf server.type=fastapi --conf image.name=myimage

--- a/content/docs/command-reference/import.md
+++ b/content/docs/command-reference/import.md
@@ -19,7 +19,7 @@ necessary `.mlem` metafiles for them. This is useful to quickly make existing
 data and model files compatible with MLEM, which then can be used in future
 operations such as `mlem apply`.
 
-This command provides a quick and easy alternative to writing python code to
+This command provides a quick and easy alternative to writing Python code to
 load those models/datasets into object for subsequent usage in MLEM context.
 
 ## Options

--- a/content/docs/command-reference/index.md
+++ b/content/docs/command-reference/index.md
@@ -11,7 +11,7 @@ For a list of all commands, type `mlem -h`
   [mlem init](/doc/command-reference/init).
 - Save Models and Data with MLEM.
 - Load and Apply models with [mlem apply](/doc/command-reference/apply).
-- Build models into python packages or docker images with
+- Build models into Python packages or Docker images with
   [mlem build](/doc/command-reference/build).
 - Serve your models by exposing their methods as endpoints using
   [mlem serve](/doc/command-reference/serve).

--- a/content/docs/command-reference/serve.md
+++ b/content/docs/command-reference/serve.md
@@ -26,7 +26,7 @@ the `/docs` endpoint.
 HTTP Requests to the model-server can be made either with the corresponding
 built-in client, or common HTTP clients, such as [`curl`](https://curl.se/) and
 [`httpie`](https://httpie.io/) CLIs, or the
-[`requests` python library](https://docs.python-requests.org/).
+[`requests` Python library](https://docs.python-requests.org/).
 
 ## Options
 

--- a/content/docs/get-started/building.md
+++ b/content/docs/get-started/building.md
@@ -9,7 +9,7 @@ a Docker image, or export your model into another format. For this tutorial we
 will create a pip-ready package from our model. You can see the full list of
 available builders [here](/doc/user-guide/mlem-abcs#builder).
 
-## Creating python package
+## Creating Python package
 
 To create a `build/` directory with pip package run this command:
 
@@ -34,7 +34,7 @@ quick reference you can run `mlem types builder` for list of builders and
 
 </details>
 
-## Exploring python package
+## Exploring Python package
 
 Let’s see what we’ve got
 
@@ -55,7 +55,7 @@ package. This includes sources, requirements,
 [setup.py](https://docs.python.org/3/distutils/setupscript.html), and the model
 itself.
 
-## Using python package
+## Using Python package
 
 Now you can distribute and install the package. Its code declares all the same
 methods our model had, so you can try to use it like this:

--- a/content/docs/get-started/index.md
+++ b/content/docs/get-started/index.md
@@ -90,7 +90,7 @@ explore them one by one in the next few pages:
 - **[Applying models](/doc/get-started/applying)** explains how to load and
   apply models
 - **[Exporting models (building)](/doc/get-started/building)** describes how
-  models can be built into python packages, docker images, etc.
+  models can be built into Python packages, Docker images, etc.
 - **[Serving models](/doc/get-started/serving)** shows how to create a service
   from your model
 - **[Deploying models](/doc/get-started/deploying)** shows how you can deploy

--- a/content/docs/get-started/saving.md
+++ b/content/docs/get-started/saving.md
@@ -7,7 +7,7 @@ but soon we'll save something with MLEM to fill it up.
 
 To save models with MLEM you just need to use `mlem.api.save()` method instead
 of some other way you saved your model before. Let's take a look at the
-following python script:
+following Python script:
 
 ```py
 # train.py

--- a/content/docs/use-cases/cicd.md
+++ b/content/docs/use-cases/cicd.md
@@ -10,7 +10,7 @@ CI/CD pipelines.
 - **Packaging and publishing models**: A common need is when you need to wrap
   your ML model in a specific format and publish it in some registry. Examples
   include turning your ML model into a Python package and publishing it on PyPi,
-  building a docker image and pushing it to DockerHub, or just exporting your
+  building a Docker image and pushing it to Docker Hub, or just exporting your
   model to ONNX and publishing it as an artifact to Artifactory.
 
 - **Deploying models**: Another common scenario is when you want to deploy a

--- a/content/docs/user-guide/extending.md
+++ b/content/docs/user-guide/extending.md
@@ -48,7 +48,7 @@ point key, where
 
 - `abs_name` is `MlemABC.abs_name` of the interface you are implementing
 - `type` is a value of `type` field name of your class
-- `module path` is full path to python module
+- `module path` is full path to Python module
 - `class name` is the name of your class
 
 You can see examples in MLEM's

--- a/content/docs/user-guide/mlem-abcs.md
+++ b/content/docs/user-guide/mlem-abcs.md
@@ -55,9 +55,9 @@ Represents different types of requirements for MLEM Object.
 
 Implementations:
 
-- `installable` - a python requirement typically installed through `pip`. Can
+- `installable` - a Python requirement typically installed through `pip`. Can
   have specific version and alternative package name.
-- `custom` - a python requirement in the form of a local `.py` file or a python
+- `custom` - a Python requirement in the form of a local `.py` file or a python
   package. Contains name and source code for the module/package.
 - `unix` - unix package typically installed through `apt` or `yum`
 
@@ -73,7 +73,7 @@ Implementations:
 - `pickle` - simply unpickle the contens of file and use default MLEM object
   analyzer. Works with pickled files.
 - `pandas` - try to read a file into `pandas.DataFrame`. Works with files saved
-  with pandas in formats like
+  with Pandas in formats like
   `csv, json, excel, parquet, feather, stata, html, parquet`. Some formats
   require additional dependencies.
 
@@ -104,14 +104,14 @@ implementation.
 There are implementations of this class for all supported libraries: `xgboost`,
 `catboost`, `lightgbm`, `torch`, `sklearn`.
 
-The one notable implementation is `callable`: it treats any python callable
+The one notable implementation is `callable`: it treats any Python callable
 object as a model with a single method `__call__`. That means you can turn
 functions and class methods into MLEM Models as well!
 
 ## ModelIO
 
 Represents a way that model can be saved and loaded. A required field of
-`ModelType` class. If a ML library has it's own way to save and load models, it
+`ModelType` class. If a ML library has its own way to save and load models, it
 goes here.
 
 **Base class**: `mlem.core.model.ModelIO`
@@ -120,12 +120,12 @@ There are implementations for all supported libraries: `torch_io`, `xgboost_io`,
 `lightgbm_io`, `catboost_io`
 
 Also, universal `simple_pickle` is available, which simply pickles the model
-(used by sklearn, for example).
+(used by `sklearn`, for example).
 
 There is also separate `pickle` implementation, which can detect other model
 types inside your object and use their IO's for them. This is very handy when
-you for example wrap your torch NN with a python function: the function part
-will be pickled, and NN will be saved using `torch_io`.
+you for example wrap your `torch` NN with a Python function: the function part
+will be pickled, and the NN will be saved using `torch_io`.
 
 # Data
 
@@ -143,7 +143,7 @@ Holds metadata about data, like type, dimensions, column names etc.
 
 Python:
 
-- `primitive` - any of the python primitives
+- `primitive` - any of the Python primitives
 - `tuple` - a tuple of objects, each can have different type
 - `list` - a list of objects, but they should be the same type
 - `tuple_like_list` - a list of objects, each can have different type
@@ -155,7 +155,7 @@ Pandas:
   indexes
 - `series` - `pd.Series`. Holds info about columns, their types and indexes
 
-Numpy:
+NumPy:
 
 - `ndarray` - `np.ndarray`. Holds info about type and dimensions
 - `number` - `np.number`. Holds info about type
@@ -180,7 +180,7 @@ Holds all the information needed to read dataset.
 
 **Fields**:
 
-- `data_type` - resulting data_type
+- `data_type` - resulting data type
 
 **Implementations**:
 
@@ -203,7 +203,7 @@ Writes data to files, producing a list of `Artifact` and corresponding
 
 ## Artifact
 
-Represents a file save in some storage.
+Represents a file saved in some storage.
 
 **Base class**: `mlem.core.artifacts.Artifact`
 
@@ -281,13 +281,13 @@ Related commands: [API](/doc/api-reference/build),
 
 Python packages:
 
-- `pip` - create a directory with python package from model
-- `whl` - create a `.whl` file with python package
+- `pip` - create a directory with Python package from model
+- `whl` - create a `.whl` file with Python package
 
 Docker:
 
-- `docker_dir` - create a directory with context for docker image building
-- `docker` - build a docker image from model
+- `docker_dir` - create a directory with context for Docker image building
+- `docker` - build a Docker image from model
 
 # Deployment
 

--- a/content/docs/user-guide/what-is-mlem.md
+++ b/content/docs/user-guide/what-is-mlem.md
@@ -1,11 +1,11 @@
 # What is MLEM
 
-**MLEM** is an open-source python tool, providing an easy and flexible way to
+**MLEM** is an open-source Python tool, providing an easy and flexible way to
 package and serve Machine Learning models.
 
-**MLEM** allows you transform your models into python modules to use
+**MLEM** allows you transform your models into Python modules to use
 programmatically, or as fully deployable services packaged in easily shippable
-docker images.
+Docker images.
 
 **MLEM** defines standard interfaces and formats for datasets and models, and a
 modular, flexible design. This allows supporting a wide variety of model types


### PR DESCRIPTION
Various spelling and grammar improvements, e.g.:

* python -> Python
* docker -> Docker
* DockerHub -> Docker Hub
* Numpy -> NumPy
* pandas -> Pandas
* it's -> its (where applicable)