### PR TITLE
Use internal-use tag for link check

### DIFF
--- a/.github/workflows/link-check-all.yml
+++ b/.github/workflows/link-check-all.yml
@@ -5,4 +5,4 @@ on:
     - cron: '0 0 * * *'
 jobs:
   run:
-    uses: iterative/link-check/.github/workflows/link-check-all.yml@v0.13.0
+    uses: iterative/link-check/.github/workflows/link-check-all.yml@internal-use

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -3,4 +3,4 @@ on:
   deployment_status:
 jobs:
   run:
-    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@only-failed-links-in-workflows
+    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@internal-use

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -3,4 +3,4 @@ on:
   deployment_status:
 jobs:
   run:
-    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@v0.13.0
+    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@only-failed-links-in-workflow

--- a/.github/workflows/link-check-deploy.yml
+++ b/.github/workflows/link-check-deploy.yml
@@ -3,4 +3,4 @@ on:
   deployment_status:
 jobs:
   run:
-    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@only-failed-links-in-workflow
+    uses: iterative/link-check/.github/workflows/link-check-deployment-status.yml@only-failed-links-in-workflows

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -4,10 +4,6 @@
 It seamlessly supports a variety of scenarios like real-time serving and batch
 processing.
 
-[test good link](https://www.google.com)
-[test bad link](https://www.google.com/notarealpage)
-[test invalid link](https://www.aadvfnnbdfs.net)
-
 <admon type="tip">
 
 When combined with [GTO](https://github.com/iterative/gto), MLEM allows you to

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -4,6 +4,10 @@
 It seamlessly supports a variety of scenarios like real-time serving and batch
 processing.
 
+[test good link](https://www.google.com)
+[test bad link](https://www.google.com/notarealpage)
+[test invalid link](https://www.aadvfnnbdfs.net)
+
 <admon type="tip">
 
 When combined with [GTO](https://github.com/iterative/gto), MLEM allows you to


### PR DESCRIPTION
# https://github.com/iterative/dvc.org/pull/3878 = https://github.com/iterative/mlem.ai/pull/155 = https://github.com/iterative/cml.dev/pull/300 = https://github.com/iterative/iterative.ai/pull/542

These PRs change the version of link check to be pinned to a git tag on the link check repo called `internal-use`, which currently points to https://github.com/iterative/link-check/pull/22, making the default check only show failing links instead of showing all links including passing ones.

This `internal-use` git tag can be moved to different versions and updated independently of the default branch, which could be useful for temporarily testing features on our sites with the link checker.

![image](https://user-images.githubusercontent.com/9111807/185021989-d07aad38-deec-4c13-9e67-b609e24048b1.png)