### PR TITLE
Fix image path issue

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,6 +15,20 @@ const siteMetadata = {
 const plugins = [
   'gatsby-plugin-eslint',
   {
+    resolve: 'gatsby-source-filesystem',
+    options: {
+      name: 'images',
+      path: `${__dirname}/src/images`
+    }
+  },
+  {
+    resolve: 'gatsby-source-filesystem',
+    options: {
+      name: 'images',
+      path: path.join(__dirname, 'static', 'img')
+    }
+  },
+  {
     resolve: '@dvcorg/gatsby-theme-iterative',
     options: {
       simpleLinkerTerms: require('./content/linked-terms'),
@@ -88,13 +102,6 @@ const plugins = [
           type: 'image/png'
         }
       ]
-    }
-  },
-  {
-    resolve: 'gatsby-source-filesystem',
-    options: {
-      name: 'images',
-      path: `${__dirname}/src/images`
     }
   },
   'gatsby-plugin-meta-redirect'

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "gatsby-plugin-postcss": "5.23.0",
     "gatsby-plugin-react-helmet": "5.23.0",
     "gatsby-plugin-remove-serviceworker": "1.0.0",
-    "gatsby-plugin-sharp": "4.23.0",
     "gatsby-plugin-svgr": "3.0.0-beta.0",
     "gatsby-plugin-typescript": "4.23.0",
     "gatsby-remark-images": "6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,27 +7183,6 @@ gatsby-plugin-remove-serviceworker@1.0.0:
   resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz#9fb433bc8bd766e14e1d3711c4ac6f051e1dff7c"
   integrity sha512-8uQ/6PiM718BTZAgmQeEO6ULrJgLugmDVAkUGv5xxF0luBNrbboDgpsG0z1fbsotSDTzLWyULR0zzGNfWZaY7w==
 
-gatsby-plugin-sharp@4.23.0:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-4.23.0.tgz#c5e5e6fb548380cdad6cd5120bd47d2a5716756a"
-  integrity sha512-w3uIP0W9hgsaoby529mg2UAqeN0fyw4JyT4a5b2x4u4odjfaOuesl4mcbjqfTESwRgwRWxs406Afq9IGIW2wtw==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@gatsbyjs/potrace" "^2.3.0"
-    async "^3.2.4"
-    bluebird "^3.7.2"
-    debug "^4.3.4"
-    filenamify "^4.3.0"
-    fs-extra "^10.1.0"
-    gatsby-core-utils "^3.23.0"
-    gatsby-plugin-utils "^3.17.0"
-    lodash "^4.17.21"
-    mini-svg-data-uri "^1.4.4"
-    probe-image-size "^7.2.3"
-    semver "^7.3.7"
-    sharp "^0.30.7"
-    svgo "^2.8.0"
-
 gatsby-plugin-sharp@^4.14.1:
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-4.19.0.tgz#3e1f5b1dc1c1caabd2971aa7852eebe577ed14f3"


### PR DESCRIPTION
The markdown image on docs was not loading properly.

cc: @madhur-tandon 
>I am unable to use pictures inside the docs
shouldn't [](/static/img/ecr.png) have just worked?
Is there any example I can see? I think [mlem.ai](http://mlem.ai/) doesn't have any pics
so what I get is this:
> >`Error: No matching file found for src "/img/ecr.png" in static folder "static". Please check static folder name and that file exists at "static/img
  /ecr.png". This error will probably cause a "GraphQLDocumentError" later in build. All converted field paths MUST resolve to a matching file in the
   "static" folder.`
