### PR TITLE
Re-add Sentry for theme v0.1.16

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -104,7 +104,8 @@ const plugins = [
       ]
     }
   },
-  'gatsby-plugin-meta-redirect'
+  'gatsby-plugin-meta-redirect',
+  '@sentry/gatsby'
 ]
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@dvcorg/gatsby-theme-iterative": "0.1.16",
     "@octokit/graphql": "5.0.1",
-    "@sentry/gatsby": "7.13.0",
+    "@sentry/gatsby": "^7.13.0",
     "@svgr/webpack": "6.3.1",
     "autoprefixer": "10.4.12",
     "classnames": "2.3.2",

--- a/sentry.config.js
+++ b/sentry.config.js
@@ -1,0 +1,4 @@
+import sentryConfig from '@dvcorg/gatsby-theme-iterative/sentry-config'
+import * as Sentry from '@sentry/gatsby'
+
+Sentry.init(sentryConfig)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,7 +2396,7 @@
     "@sentry/utils" "7.13.0"
     tslib "^1.9.3"
 
-"@sentry/gatsby@7.13.0":
+"@sentry/gatsby@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@sentry/gatsby/-/gatsby-7.13.0.tgz#50965623d43dc437704660a6cbef8ac2927043fc"
   integrity sha512-kHaO4dl5dfqUyw7dxdvRo4FRKqOPMW6R26zokmlsYNKDPcHlYZXOpHZpCgJgTKV6ZuKdyfh6RRur2d/yIzvaNg==


### PR DESCRIPTION
gatsby-theme-iterative ~v0.1.15 broke sentry integration on accident, and given there being difficulty with packing sentry with the theme because of how `sentry.config.js` works, we've opted to at least temporarily have the consumer site declare `@sentry/gatsby` in its `gatsby-config.js` and be able to consume a default config provided by the package. This could change when we figure out a better implementation, but this is primarily to just get sentry working again.