### PR TITLE
Fix stars pulling from DVC

### DIFF
--- a/src/utils/hooks/useStars.tsx
+++ b/src/utils/hooks/useStars.tsx
@@ -16,7 +16,7 @@ export default function useStars(): number | null {
 
   // Update on the client side
   useEffect(() => {
-    fetch(`/api/github/stars`).then(res => {
+    fetch(`/api/github/stars?repo=mlem.ai`).then(res => {
       if (res.status === 200) {
         res.json().then(json => {
           setStars(json.stars)

--- a/src/utils/hooks/useStars.tsx
+++ b/src/utils/hooks/useStars.tsx
@@ -16,7 +16,7 @@ export default function useStars(): number | null {
 
   // Update on the client side
   useEffect(() => {
-    fetch(`/api/github/stars?repo=mlem.ai`).then(res => {
+    fetch(`/api/github/stars?repo=mlem`).then(res => {
       if (res.status === 200) {
         res.json().then(json => {
           setStars(json.stars)


### PR DESCRIPTION
This PR adds a query to the stars request made by this website to use the repo for the project in question, where it currently is pulling from dvc.

https://github.com/iterative/cml.dev/pull/363 is the same thing for cml.dev