### PR TITLE
Upgrade theme to 0.1.23 to fix Plausible

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@dvcorg/gatsby-theme-iterative": "0.1.16",
+    "@dvcorg/gatsby-theme-iterative": "0.1.23",
     "@dvcorg/websites-server": "^0.0.10",
     "@octokit/graphql": "5.0.1",
     "@sentry/gatsby": "^7.13.0",

--- a/src/components/SEO/index.tsx
+++ b/src/components/SEO/index.tsx
@@ -85,12 +85,6 @@ const SEO: React.FC<ISEOProps> = ({
       {seo.image && <meta name="twitter:image" content={seo.image} />}
       {seo.imageAlt && <meta name="twitter:image:alt" content={seo.imageAlt} />}
       <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0f1624" />
-      <script
-        defer
-        data-domain="mlem.ai"
-        src="https://dvc.org/pl/js/script.js"
-        data-api="https://dvc.org/pl/api/event"
-      ></script>
     </Helmet>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,10 +1084,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@dvcorg/gatsby-theme-iterative@0.1.16":
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/@dvcorg/gatsby-theme-iterative/-/gatsby-theme-iterative-0.1.16.tgz#0978510cc01fbd6458a7e04865398fe70ff0cae8"
-  integrity sha512-iqvVaRbpCVE95hjyXXQ4rdEyykeYILFvYkGfInD/Yr8kSXngmmny2ZIdt7z6SF5Q2L0hDYCJhxM9tncf5Ud1Tw==
+"@dvcorg/gatsby-theme-iterative@0.1.23":
+  version "0.1.23"
+  resolved "https://registry.yarnpkg.com/@dvcorg/gatsby-theme-iterative/-/gatsby-theme-iterative-0.1.23.tgz#8e13533008999fa8398a69525f920557a00bce45"
+  integrity sha512-LrEQvAHL0fPRsHw7Ymi4DNxw7H6CHJnIPQYbGbj1h8PI+IvBoTrnhpLoGtOPJSna/EUILrErWP+i1FSFcP1oAQ==
   dependencies:
     "@reach/portal" "^0.17.0"
     "@reach/router" "^1.3.4"


### PR DESCRIPTION
https://github.com/iterative/dvc.org/pull/4112 = https://github.com/iterative/iterative.ai/pull/686 = https://github.com/iterative/mlem.ai/pull/221 = https://github.com/iterative/cml.dev/pull/373

This PR consumes the maintenance version of `gatsby-theme-iterative`, which includes specifically the plausible fixes without the recent breaking changes. This will allow us to get this plausible fix without blocking it behind other changes needed to upgrade to the new breaking version.