### PR TITLE
Fix: mlem clone examples in user guide

### DIFF
--- a/content/docs/user-guide/remote-objects/index.md
+++ b/content/docs/user-guide/remote-objects/index.md
@@ -31,7 +31,7 @@ You can load [MLEM objects] from remote locations inside Python code with
 from mlem.api import load
 
 model = load(
-    "rf",
+    "models/rf",
     project="https://github.com/iterative/example-mlem-get-started",
     rev="main"
 )
@@ -48,7 +48,7 @@ You can download MLEM objects to the local environment in with `mlem clone`
 (CLI).
 
 ```cli
-$ mlem clone rf \
+$ mlem clone models/rf \
   --project https://github.com/iterative/example-mlem-get-started \
   ml_model
 ⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/main/models/rf.mlem


### PR DESCRIPTION
Hi,

while trying to learn mlem I had problem running the command in your example.
There what happens:
```sh
❯ mlem clone rf \
  --project https://github.com/iterative/example-mlem-get-started \
  ml_model
❌ MLEM object was not found at `https://github.com/iterative/example-mlem-get-started/tree/main/rf`
```

Looking at `https://github.com/iterative/example-mlem-get-started`, I noticed that the `rf` model is in the folder `models`. If I run
```
❯ mlem clone models/rf \
  --project https://github.com/iterative/example-mlem-get-started \
  ml_model
⏳️ Loading meta from https://github.com/iterative/example-mlem-get-started/tree/main/models/rf.mlem
🐏 Cloning https://github.com/iterative/example-mlem-get-started/tree/main/models/rf.mlem
💾 Saving model to ml_model.mlem
```
the problem is fixed.

I thought of pushing this fix directly :)