### PR TITLE
Update theme to 0.1.24 for GTO docs args linker fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@dvcorg/gatsby-theme-iterative": "0.1.23",
+    "@dvcorg/gatsby-theme-iterative": "0.1.24",
     "@dvcorg/websites-server": "^0.0.10",
     "@octokit/graphql": "5.0.1",
     "@sentry/gatsby": "^7.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1084,10 +1084,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@dvcorg/gatsby-theme-iterative@0.1.23":
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/@dvcorg/gatsby-theme-iterative/-/gatsby-theme-iterative-0.1.23.tgz#8e13533008999fa8398a69525f920557a00bce45"
-  integrity sha512-LrEQvAHL0fPRsHw7Ymi4DNxw7H6CHJnIPQYbGbj1h8PI+IvBoTrnhpLoGtOPJSna/EUILrErWP+i1FSFcP1oAQ==
+"@dvcorg/gatsby-theme-iterative@0.1.24":
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/@dvcorg/gatsby-theme-iterative/-/gatsby-theme-iterative-0.1.24.tgz#156264e5cb72e21c5dff1926306ff0121683c79e"
+  integrity sha512-NFmiq+tJ7UkrkGY+36KC9XkIqtaJFxiz19RN9Zq14pHA8ZKjSxBG+qqFyR+kxo7KcF9CIJivoSHNQ10YZzhiOg==
   dependencies:
     "@reach/portal" "^0.17.0"
     "@reach/router" "^1.3.4"


### PR DESCRIPTION
This PR takes #199 and updates mlem.ai to `@dvcorg/gatsby-theme-iterative`, a maintenance backport adding the `args-linker` fix in a fully compatible way that we can get the fix in ASAP and unblock GTO docs.