### PR TITLE
Add missing security headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@dvcorg/gatsby-theme-iterative": "0.1.24",
-    "@dvcorg/websites-server": "^0.0.10",
+    "@dvcorg/websites-server": "^0.0.13",
     "@octokit/graphql": "5.0.1",
     "@sentry/gatsby": "^7.13.0",
     "@svgr/webpack": "6.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,10 +1230,10 @@
     unist-util-remove-position "^4.0.1"
     unist-util-visit "^4.1.0"
 
-"@dvcorg/websites-server@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@dvcorg/websites-server/-/websites-server-0.0.10.tgz#05c86dbc26a575fa08026f841b7d11190248e851"
-  integrity sha512-WSVdW6MUUI4dRGWIoyyF/EaoXAerVXVH0KbeM6BrTO7QaxNmQgibeuPNNpozxOUO8SbFtBrH3AMTps14fpGijg==
+"@dvcorg/websites-server@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@dvcorg/websites-server/-/websites-server-0.0.13.tgz#824fb2407a10c4e66c62c3758db29a3118845eac"
+  integrity sha512-p6mlj54afEjJC/b+PPh3w+msmoUthbZZtQ513UHKfXzuyhH4V/HFpYYUygaEhWQU9vdoI1B5jVJn3uh1DYsAhA==
   dependencies:
     "@dvcorg/gatsby-theme-iterative" "^0.1.17"
     "@hapi/wreck" "^18.0.0"
@@ -1243,12 +1243,15 @@
     dotenv "^16.0.1"
     express "^4.18.1"
     fs-extra "^10.1.0"
+    helmet "^6.0.0"
     http-proxy-middleware "^2.0.6"
     isomorphic-fetch "^3.0.0"
+    lodash "^4.17.21"
     node-cache "^5.1.2"
+    permissions-policy "^0.6.0"
     react "^18.2.0"
     s3-client "^4.4.2"
-    serve-handler "^6.1.3"
+    serve-handler "^6.1.5"
 
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
@@ -8655,6 +8658,11 @@ header-case@^2.0.4:
     capital-case "^1.0.4"
     tslib "^2.0.3"
 
+helmet@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-6.0.0.tgz#8e183820ddccd7729a206ad73c577b264f495595"
+  integrity sha512-FO9RpR1wNJepH/GbLPQVtkE2eESglXL641p7SdyoT4LngHFJcZheHMoyUcjCZF4qpuMMO1u5q6RK0l9Ux8JBcg==
+
 hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -10685,7 +10693,7 @@ minimatch@3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@3.1.2, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -11642,6 +11650,11 @@ perfect-scrollbar@^1.5.5:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/perfect-scrollbar/-/perfect-scrollbar-1.5.5.tgz#41a211a2fb52a7191eff301432134ea47052b27f"
   integrity sha512-dzalfutyP3e/FOpdlhVryN4AJ5XDVauVWxybSkLZmakFE2sS3y3pc4JnSprw8tGmHvkaG5Edr5T7LBTZ+WWU2g==
+
+permissions-policy@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/permissions-policy/-/permissions-policy-0.6.0.tgz#9c01b1a8e360ab4955e20a7946abcb0fd34d276d"
+  integrity sha512-VfN72swhRiuvfejFP/N5hOVCyriBgzy1KiLE8mjN2KkCJCOtFv2N221SVUHYl0OPXIOoqu7tkc7efreiN7encA==
 
 phin@^2.9.1:
   version "2.9.3"
@@ -13470,7 +13483,7 @@ serialize-javascript@^6.0.0:
   dependencies:
     randombytes "^2.1.0"
 
-serve-handler@6.1.3, serve-handler@^6.1.3:
+serve-handler@6.1.3:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.3.tgz#1bf8c5ae138712af55c758477533b9117f6435e8"
   integrity sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==
@@ -13480,6 +13493,20 @@ serve-handler@6.1.3, serve-handler@^6.1.3:
     fast-url-parser "1.1.3"
     mime-types "2.1.18"
     minimatch "3.0.4"
+    path-is-inside "1.0.2"
+    path-to-regexp "2.2.1"
+    range-parser "1.2.0"
+
+serve-handler@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-6.1.5.tgz#a4a0964f5c55c7e37a02a633232b6f0d6f068375"
+  integrity sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==
+  dependencies:
+    bytes "3.0.0"
+    content-disposition "0.5.2"
+    fast-url-parser "1.1.3"
+    mime-types "2.1.18"
+    minimatch "3.1.2"
     path-is-inside "1.0.2"
     path-to-regexp "2.2.1"
     range-parser "1.2.0"


### PR DESCRIPTION
Similar to https://github.com/iterative/iterative.ai/pull/704 for `mlem.ai`.

https://securityheaders.com/?q=https%3A%2F%2Fmlem-ai-security-header-6cq3fp.herokuapp.com%2F&followRedirects=on
<img width="1250" alt="Screenshot 2022-11-29 at 17 21 37" src="https://user-images.githubusercontent.com/20840228/204519094-c16f4f06-b3a5-45e4-b20f-84875d7e0c30.png">
