### PR TITLE
Add `streamlit` and `preprocess`/`postprocess` to docs

### DIFF
--- a/content/docs/api-reference/save.md
+++ b/content/docs/api-reference/save.md
@@ -10,6 +10,8 @@ def save(
     sample_data=None,
     fs: Optional[AbstractFileSystem] = None,
     params: Dict[str, str] = None,
+    preprocess: Union[Any, Dict[str, Any]] = None,
+    postprocess: Union[Any, Dict[str, Any]] = None,
 ) -> MlemObject
 ```
 
@@ -38,6 +40,8 @@ systems (eg: `S3`). The function returns and saves the object as a
   metadata
 - `fs` (optional) - FileSystem for the `path` argument
 - `params` (optional) - arbitrary params for object
+- `preprocess` (optional) - applies before the model
+- `postprocess`(optional) - applies after the model
 
 ## Returns
 
@@ -63,4 +67,28 @@ model = DecisionTreeClassifier().fit(train, target)
 path = os.path.join(os.getcwd(), "saved-model")
 
 save(model, path, sample_data=train)
+```
+
+## Example: use pre- and post-processors
+
+```py
+def apply_emdedding(word):
+    # apply embedding
+    ...
+    return embedding
+
+
+def return_classname(prediction):
+    if len(prediction.shape) > 1:
+        return "A surname" if prediction[0][0] < prediction[0][1] else "Not a surname"
+    return "A surname" if prediction[0] else "Not a surname"
+
+
+mlem.api.save(
+    classify_word,  # trained on a dataset created by applying `apply_emdedding`
+    "surname_classifier",
+    preprocess=apply_emdedding,
+    postprocess=return_classname,
+    sample_data="Gagarin",
+)
 ```

--- a/content/docs/api-reference/save.md
+++ b/content/docs/api-reference/save.md
@@ -39,8 +39,8 @@ like about running `postprocess(model(preprocess(x)))`. See examples below.
 - **`path`** (required) - If not located on LocalFileSystem, then should be
   urior `fs` argument should be provided
 - `project` (optional) - path to mlem project (optional)
-- `sample_data` (optional) - If the object is a model or function, you
-  canprovide input data sample, so MLEM will include it's schemain the model's
+- `sample_data` (optional) - If the object is a model or function, you can
+  provide input data sample, so MLEM will include it's schema in the model's
   metadata
 - `fs` (optional) - FileSystem for the `path` argument
 - `params` (optional) - arbitrary params for object

--- a/content/docs/api-reference/save.md
+++ b/content/docs/api-reference/save.md
@@ -29,6 +29,10 @@ Saves a given object to a given path. The path can belong to different file
 systems (eg: `S3`). The function returns and saves the object as a
 [MLEM Object](/doc/user-guide/basic-concepts#mlem-objects).
 
+We often need to apply some preprocessing before and after the model is applied,
+for that we have `preprocess` and `postprocess` arguments. You can think of them
+like about running `postprocess(model(preprocess(x)))`. See examples below.
+
 ## Parameters
 
 - **`obj`** (required) - Object to dump
@@ -71,6 +75,8 @@ save(model, path, sample_data=train)
 
 ## Example: use pre- and post-processors
 
+`preprocess` and `postprocess` can be functions or MLEM models:
+
 ```py
 def apply_emdedding(word):
     # apply embedding
@@ -89,6 +95,26 @@ mlem.api.save(
     "surname_classifier",
     preprocess=apply_emdedding,
     postprocess=return_classname,
+    sample_data="Gagarin",
+)
+```
+
+If you need different pre- and post-processor for different model methods, you
+can specify them with dictionaries (let's assume `classify_word` is a sklearn
+model and have two methods: `predict` and `predict_proba`):
+
+```py
+mlem.api.save(
+    classify_word,  # trained on a dataset created by applying `apply_emdedding`
+    "surname_classifier",
+    preprocess={
+        "predict": apply_emdedding,
+        "predict_proba": apply_emdedding,
+    },
+    postprocess={
+        "predict": lambda p: "A surname" if p[0] else "Not a surname",
+        "predict_proba": lambda p: "A surname" if p[0][0] < p[0][1] else "Not a surname",
+    },
     sample_data="Gagarin",
 )
 ```

--- a/content/docs/command-reference/apply-remote.md
+++ b/content/docs/command-reference/apply-remote.md
@@ -7,9 +7,10 @@ Otherwise, it will be printed to `stdout`.
 ## Synopsis
 
 ```usage
-usage: mlem apply-remote [-d <path>] [-p <path>] [--rev <commitish>]
-                         [-o <path>] [--tp <path>] [-m <text>]
-                         [--json] [-f <text>] [-h]
+usage: mlem apply-remote [--raw] [-d <path>] [-p <path>]
+                         [--rev <commitish>] [-o <path>]
+                         [--tp <path>] [-m <text>] [--json]
+                         [-f <text>] [-h]
                          [<client> [client options] | --load <declaration>]
 
 Builtin clients:
@@ -30,6 +31,7 @@ against the `fastapi` and `rmq` server types, correspondingly.
 
 ## Options
 
+- `--raw <boolean>` - Pass values as-is without serializers [default: False]
 - `-d <path>`, `--data <path>` - Path to MLEM dataset [required]
 - `-p <path>`, `--project <path>` - Path to MLEM project [default: (none)]
 - `--rev <commitish>` - Repo revision to use [default: (none)]

--- a/content/docs/command-reference/migrate.md
+++ b/content/docs/command-reference/migrate.md
@@ -1,0 +1,35 @@
+# migrate
+
+Migrate metadata objects from older MLEM version
+
+## Synopsis
+
+```usage
+usage: mlem migrate [-p <path>] [-r] [-h]
+                    path
+
+arguments:
+  path             URI of the MLEM object you are migrating or directory to
+                   migrate
+```
+
+## Description
+
+This command will help you migrate to newer MLEM versions. When backward
+compatibility was broken and the new MLEM version can't work with older `.mlem`
+metafiles, you can run `mlem migrate` to re-write the metafiles to adhere to the
+new format.
+
+## Options
+
+- `-p <path>`, `--project <path>` - Path to MLEM project [default: (none)]
+- `-r`, `--recursive` - Enable recursive search of directory
+- `-h`, `--help` - Show this message and exit.
+
+## Examples
+
+Migrate all files in the current dir and all its subdirs to the new format with:
+
+```cli
+$ mlem migrate -r .
+```

--- a/content/docs/command-reference/serve.md
+++ b/content/docs/command-reference/serve.md
@@ -22,6 +22,7 @@ usage: mlem serve [--request_serializer <str>]
 Builtin servers:
 - fastapi
 - rmq
+- streamlit
 ```
 
 ## Description

--- a/content/docs/object-reference/build/docker.md
+++ b/content/docs/object-reference/build/docker.md
@@ -49,7 +49,7 @@
 
 **Fields**:
 
-- `python_version: str = "3.10.5"` - Python version to use default: version of
+- `python_version: str = "3.9.5"` - Python version to use default: version of
   running interpreter
 
 - `run_cmd: str = "sh run.sh"` - command to run in container

--- a/content/docs/object-reference/deployment/docker.md
+++ b/content/docs/object-reference/deployment/docker.md
@@ -34,7 +34,11 @@
 
 **Fields**:
 
+- `declaration: MlemDeployment` _(required)_ - Deployment declaration used
+
 - `model_hash: str` - Hash of deployed model meta
+
+- `model_link: TypedMlemLink` - Link to deployed model
 
 - `image: DockerImage` - Built image
 
@@ -67,7 +71,7 @@
 
 **Fields**:
 
-- `python_version: str = "3.10.5"` - Python version to use default: version of
+- `python_version: str = "3.9.5"` - Python version to use default: version of
   running interpreter
 
 - `run_cmd: str = "sh run.sh"` - command to run in container

--- a/content/docs/object-reference/deployment/heroku.md
+++ b/content/docs/object-reference/deployment/heroku.md
@@ -47,7 +47,11 @@
 
 **Fields**:
 
+- `declaration: MlemDeployment` _(required)_ - Deployment declaration used
+
 - `model_hash: str` - Hash of deployed model meta
+
+- `model_link: TypedMlemLink` - Link to deployed model
 
 - `app: HerokuAppMeta` - Created heroku app
 

--- a/content/docs/object-reference/deployment/kubernetes.md
+++ b/content/docs/object-reference/deployment/kubernetes.md
@@ -48,7 +48,11 @@
 
 **Fields**:
 
+- `declaration: MlemDeployment` _(required)_ - Deployment declaration used
+
 - `model_hash: str` - Hash of deployed model meta
+
+- `model_link: TypedMlemLink` - Link to deployed model
 
 - `image: DockerImage` - Docker Image being used for Deployment
 

--- a/content/docs/object-reference/deployment/sagemaker.md
+++ b/content/docs/object-reference/deployment/sagemaker.md
@@ -10,7 +10,11 @@
 
 **Fields**:
 
+- `declaration: MlemDeployment` _(required)_ - Deployment declaration used
+
 - `model_hash: str` - Hash of deployed model meta
+
+- `model_link: TypedMlemLink` - Link to deployed model
 
 - `image: DockerImage` - Built image
 
@@ -25,6 +29,8 @@
 - `method_signature: Signature` - Signature of deployed method
 
 - `region: str` - AWS Region
+
+- `previous: SagemakerDeployState` - Previous state
 
 ---
 

--- a/content/docs/object-reference/serving/builtin.md
+++ b/content/docs/object-reference/serving/builtin.md
@@ -10,6 +10,8 @@
 
 **Fields**:
 
+- `raw: bool = False` - Pass values as-is without serializers
+
 - `host: str = "0.0.0.0"` - Server host
 
 - `port: int = 8080` - Server port
@@ -24,7 +26,9 @@
 
     Interface that descibes model methods
 
-**No fields**
+**Fields**:
+
+- `model: MlemModel` _(required)_ - Model metadata
 
 ---
 

--- a/content/docs/object-reference/serving/rabbitmq.md
+++ b/content/docs/object-reference/serving/rabbitmq.md
@@ -18,6 +18,8 @@
 
 - `queue_prefix: str = ""` - Queue prefix
 
+- `raw: bool = False` - Pass values as-is without serializers
+
 - `timeout: float = 0` - Time to wait for response. 0 means indefinite
 
 ---

--- a/content/docs/object-reference/serving/sagemaker.md
+++ b/content/docs/object-reference/serving/sagemaker.md
@@ -15,3 +15,5 @@
 - `aws_vars: AWSVars` _(required)_ - AWS Configuration
 
 - `signature: Signature` _(required)_ - Signature of deployed method
+
+- `raw: bool = False` - Pass values as-is without serializers

--- a/content/docs/object-reference/serving/streamlit.md
+++ b/content/docs/object-reference/serving/streamlit.md
@@ -1,0 +1,29 @@
+# streamlit
+
+## `class StreamlitServer`
+
+**MlemABC parent type**: `server`
+
+**MlemABC type**: `streamlit`
+
+    Streamlit UI server
+
+**Fields**:
+
+- `request_serializer: Serializer` - Serializer to use for all requests
+
+- `response_serializer: Serializer` - Serializer to use for all responses
+
+- `standardize: bool = True` - Use standard model interface
+
+- `server_host: str = "0.0.0.0"` - Hostname for running FastAPI backend
+
+- `server_port: int = 8080` - Port for running FastAPI backend
+
+- `run_server: bool = True` - Whether to run backend server or use existing one
+
+- `ui_host: str = "0.0.0.0"` - Hostname for running Streamlit UI
+
+- `ui_port: int = 80` - Port for running Streamlit UI
+
+- `use_watchdog: bool = True` - Install watchdog for better performance

--- a/content/docs/object-reference/uri/git.md
+++ b/content/docs/object-reference/uri/git.md
@@ -1,0 +1,11 @@
+# git
+
+## `class LocalGitResolver`
+
+**MlemABC parent type**: `resolver`
+
+**MlemABC type**: `local_git`
+
+    Resolve git repositories on local fs
+
+**No fields**

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -66,6 +66,11 @@
             "source": "fastapi.md"
           },
           {
+            "slug": "streamlit",
+            "label": "Streamlit",
+            "source": "streamlit.md"
+          },
+          {
             "slug": "rabbitmq",
             "label": "RabbitMQ",
             "source": "rabbitmq.md"

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -511,6 +511,11 @@
             "slug": "sagemaker",
             "label": "SageMaker",
             "source": "sagemaker.md"
+          },
+          {
+            "slug": "streamlit",
+            "label": "Streamlit",
+            "source": "streamlit.md"
           }
         ]
       },
@@ -550,6 +555,11 @@
             "slug": "builtin",
             "label": "Builtin",
             "source": "builtin.md"
+          },
+          {
+            "slug": "git",
+            "label": "git",
+            "source": "git.md"
           },
           {
             "slug": "github",

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -51,7 +51,7 @@
       },
       {
         "slug": "models",
-        "label": "Working with models",
+        "label": "Saving models",
         "source": "models/index.md",
         "children": []
       },
@@ -261,6 +261,11 @@
         "slug": "link",
         "label": "link",
         "source": "link.md"
+      },
+      {
+        "slug": "migrate",
+        "label": "migrate",
+        "source": "migrate.md"
       },
       {
         "slug": "pprint",

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -51,7 +51,7 @@
       },
       {
         "slug": "models",
-        "label": "Saving models",
+        "label": "Working with models",
         "source": "models/index.md",
         "children": []
       },

--- a/content/docs/user-guide/models/index.md
+++ b/content/docs/user-guide/models/index.md
@@ -1,4 +1,4 @@
-# Working with models
+# Saving models
 
 To be able to use all MLEM features, you need to turn your model into a MLEM
 model first.

--- a/content/docs/user-guide/models/index.md
+++ b/content/docs/user-guide/models/index.md
@@ -1,4 +1,4 @@
-# Saving models
+# Working with models
 
 To be able to use all MLEM features, you need to turn your model into a MLEM
 model first.

--- a/content/docs/user-guide/serving/fastapi.md
+++ b/content/docs/user-guide/serving/fastapi.md
@@ -27,7 +27,7 @@ different examples instead.
 from mlem.api import serve
 
 serve(
-    model="https://github.com/iterative/example-mlem-get-started/rf",
+    model="https://github.com/iterative/example-mlem-get-started/models/rf",
     server="fastapi",
     host="0.0.0.0",
     port=8000,
@@ -38,7 +38,7 @@ serve(
 
 ```cli
 $ mlem serve fastapi \
-  --model https://github.com/iterative/example-mlem-get-started/rf \
+  --model https://github.com/iterative/example-mlem-get-started/models/rf \
   --host 0.0.0.0 --port 8000
 )
 ```
@@ -50,7 +50,7 @@ from mlem.api import apply_remote
 
 apply_remote(
     "http",
-    "https://github.com/iterative/example-mlem-get-started/iris.csv",
+    "https://github.com/iterative/example-mlem-get-started/data/iris.csv",
     method="predict",
     host="0.0.0.0",
     port=8000,
@@ -62,5 +62,5 @@ apply_remote(
 ```cli
 $ mlem apply-remote http \
     --method predict --host 0.0.0.0 --port 8000 \
-    --data https://github.com/iterative/example-mlem-get-started/iris.csv
+    --data https://github.com/iterative/example-mlem-get-started/data/iris.csv
 ```

--- a/content/docs/user-guide/serving/streamlit.md
+++ b/content/docs/user-guide/serving/streamlit.md
@@ -15,7 +15,7 @@ pip install mlem[streamlit]
 pip install fastapi uvicorn streamlit streamlit_pydantic
 ```
 
-## Examples 
+## Examples
 
 ### Running Streamlit model server from CLI
 

--- a/content/docs/user-guide/serving/streamlit.md
+++ b/content/docs/user-guide/serving/streamlit.md
@@ -52,3 +52,7 @@ serve(
     ui_port=80,
 )
 ```
+
+Note that if your model consume a sequence of items or sequence-like object
+(such as `pandas.DataFrame`), Streamlit UI will expect to receive a single item
+from that list (e.g. `pandas.Series`).

--- a/content/docs/user-guide/serving/streamlit.md
+++ b/content/docs/user-guide/serving/streamlit.md
@@ -1,0 +1,54 @@
+# Streamlit
+
+[Streamlit](https://streamlit.io) is an open-source Python library that makes it
+easy to create and share beautiful, custom web apps for machine learning and
+data science.
+
+MLEM can use Streamlit to expose your model to external users with a nice
+auto-generated UI.
+
+## Requirements
+
+```bash
+pip install mlem[streamlit]
+# or
+pip install fastapi uvicorn streamlit streamlit_pydantic
+```
+
+## Examples 
+
+### Running Streamlit model server from CLI
+
+```cli
+$ mlem serve streamlit \
+  --model https://github.com/iterative/example-mlem-get-started/models/rf
+⏳️ Loading model from https://github.com/iterative/example-mlem-get-started/tree/main/models/rf.mlem
+Starting streamlit server...
+🖇️  Adding route for /predict
+🖇️  Adding route for /predict_proba
+Checkout openapi docs at <http://0.0.0.0:8080/docs>
+INFO:     Started server process [42223]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
+
+  You can now view your Streamlit app in your browser.
+
+  URL: http://0.0.0.0:80
+```
+
+Serving a model with Streamlit automatically expose FastAPI endpoint as well.
+You can use this if you want to have two interfaces simultaneously.
+
+### Running Streamlit model server from code
+
+```python
+from mlem.api import serve
+
+serve(
+    model="https://github.com/iterative/example-mlem-get-started/models/rf",
+    server="streamlit",
+    server_port=8080,
+    ui_port=80,
+)
+```

--- a/scripts/docs/utils.py
+++ b/scripts/docs/utils.py
@@ -10,7 +10,7 @@ DOC_AUTO_REPLACE = {
     "MLEM project": "[MLEM project](/doc/user-guide/project-structure)",
     "metafile": "[MLEM Object](/doc/user-guide/basic-concepts)",
     "MLEM configuration": "[MLEM config](/doc/user-guide/configuration)",
-    "MLEM config": "[MLEM config](/doc/user-guide/configuration)",
+    # "MLEM config": "[MLEM config](/doc/user-guide/configuration)",  # repeats itself
 }
 
 


### PR DESCRIPTION
Significantly changed pages:
- https://mlem-ai-release-0-4-0-paqi5ijw.herokuapp.com/doc/user-guide/serving/streamlit
- https://mlem-ai-release-0-4-0-paqi5ijw.herokuapp.com/doc/user-guide/models
- https://mlem-ai-release-0-4-0-paqi5ijw.herokuapp.com/doc/api-reference/save

This is for 0.4.0 release of MLEM