### PR TITLE
fix: typo and page redirect 

### DIFF
--- a/content/docs/get-started/index.md
+++ b/content/docs/get-started/index.md
@@ -158,6 +158,8 @@ Try creating and running this simple `predict.py` script:
 ```py
 from mlem.api import load
 
+import pandas as pd
+
 model = load("models/rf")  # RandomForestClassifier
 features = [
     "sepal length (cm)",

--- a/content/docs/get-started/index.md
+++ b/content/docs/get-started/index.md
@@ -158,8 +158,6 @@ Try creating and running this simple `predict.py` script:
 ```py
 from mlem.api import load
 
-import pandas as pd
-
 model = load("models/rf")  # RandomForestClassifier
 features = [
     "sepal length (cm)",

--- a/content/docs/sidebar.json
+++ b/content/docs/sidebar.json
@@ -52,8 +52,7 @@
       {
         "slug": "models",
         "label": "Working with models",
-        "source": "models/index.md",
-        "children": []
+        "source": "models/index.md"
       },
       {
         "slug": "serving",
@@ -144,8 +143,7 @@
       {
         "slug": "data",
         "label": "Working with data",
-        "source": "data/index.md",
-        "children": []
+        "source": "data/index.md"
       },
       {
         "slug": "dvc",
@@ -175,8 +173,7 @@
       {
         "slug": "importing",
         "label": "Importing existing files",
-        "source": "importing/index.md",
-        "children": []
+        "source": "importing/index.md"
       },
       {
         "slug": "sdk",


### PR DESCRIPTION
- minor typo import fix
  -`pandas` was not imported here on the [get-started](https://mlem.ai/doc/get-started/?tab=Python-Code#getting-model-predictions) page
- page redirect fix
  - [Working with models](https://mlem.ai/doc/user-guide/models/#working-with-models) after clicking next, it was not going to the next page. 
  -  same with [Working with data](https://mlem.ai/doc/user-guide/data/#working-with-data) and  [Importing existing files
](https://mlem.ai/doc/user-guide/importing/#importing-existing-files)

I am not sure if the page not redirecting to the next page was intentional. However, I have made a small change to my PR fixing it. 

Thanks
