### PR TITLE
Token can come from command line too.

### DIFF
--- a/content/docs/user-guide/dvc.md
+++ b/content/docs/user-guide/dvc.md
@@ -164,7 +164,7 @@ Github).
 
 HTTPS authentication is done by setting `GITHUB_USERNAME` and `GITHUB_TOKEN`
 environment variables. You need to generate a token
-[here](https://github.com/settings/tokens).
+[here](https://github.com/settings/tokens) or via command line `gh auth token`.
 
 It's important to first authenticate with SSH, and only then with HTTPS.
 Otherwise, running `gh auth login` will complain that `GITHUB_USERNAME` and


### PR DESCRIPTION
Adding a note about tokens coming from command line, which could enable workflows like this:
```bash
$ GITHUB_USERNAME=igordertigor GITHUB_TOKEN=$(gh auth token) mlem ...
```